### PR TITLE
[프로그래머스] 87390 / n^2 배열 자르기 - 배열 (Java)

### DIFF
--- a/solve/sanghoon/programmers/[87390] n^2 배열 자르기.java
+++ b/solve/sanghoon/programmers/[87390] n^2 배열 자르기.java
@@ -1,0 +1,19 @@
+class Solution {
+    public int[] solution(int n, long left, long right) {
+        int size = (int) (right - left + 1);
+        int[] answer = new int[size];
+
+        for (int i = 0; i < size; i++) {
+            long pos = left + i;
+
+            // 1차원 배열의 pos 위치는 nxn 배열의 (x,y) 위치에 해당
+            int x = (int) (pos / n);
+            int y = (int) (pos % n);
+
+            // nxn 배열에서 (x, y)의 값은 x와 y중 더 큰 값 + 1
+            answer[i] = Math.max(x, y) + 1;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
n^2 배열 자르기
https://school.programmers.co.kr/learn/courses/30/lessons/87390

<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
0. 정수 `n`, `left`, `right`이 주어진다. (`1 <= n <= 10^7`, `0 <= left <= right < n^2`, `right - left < 10^5`)
1. 각 칸의 값이 행·열 인덱스((1, 1)부터 시작) 중 큰 쪽의 번호가 되는 n×n 계단형 배열을 만든다. (좌상단에서 대각선 방향으로 점차 확장하며 같은 숫자로 채워지는 모양)
2. 해당 배열의 행을 모두 잘라낸 뒤 이어붙여 1차원 배열을 만든다.
3. 1차원 배열에서 [left, right] 범위를 반환한다.

<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
- 배열(인덱스)

<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- 처음에는 2차원 배열을 직접 생성하고 이어붙여서 답을 구하려 했으나, 메모리 초과로 인해 실패했습니다.
  - 공간복잡도가 `O(n^2)`이고 `n`이 최대 10^7이므로 최대 100조 x 4바이트(int) 공간이 필요하여 메모리 초과 발생한 것으로 예상
- 따라서 직접 배열을 만드는 대신 각 칸에 값이 채워지는 규칙을 찾아서 결과 배열(1차원 배열)을 생성하는 방식을 사용했습니다.
  - 2차원 배열 `A`에서 `A[i][j]`에 들어가야 하는 값은 `max(i, j) + 1`과 같음
  - 2차원 배열을 펼쳐서 만든 1차원 배열 `arr`에서, 인덱스 `k`는 2차원 배열의 `(k/n, k%n)`에 해당하고 따라서 `arr[k] == A[k/n][k%n]`이 성립함
- 시간복잡도는 단일 for 루프를 순회하므로 `O(n)`, 공간복잡도는 1차원 배열을 저장하므로 `O(n)`입니다.