### PR TITLE
[프로그래머스] 87946/ 피로도

### DIFF
--- a/solve/hyunseung/programmers/[87946] 피로도.java
+++ b/solve/hyunseung/programmers/[87946] 피로도.java
@@ -1,0 +1,34 @@
+class Solution {
+    int answer = 0;
+    boolean[] visited;
+
+    public int solution(int k, int[][] dungeons) {
+        int n = dungeons.length;
+        visited = new boolean[n];
+
+        dfs(k, dungeons, 0);
+
+        return answer;
+    }
+
+    // k : 현재 피로도
+    // count : 지금까지 탐험한 던전 수
+    private void dfs(int k, int[][] dungeons, int count) {
+        // 현재까지 탐험한 개수로 최대값 갱신
+        if (count > answer) {
+            answer = count;
+        }
+
+        for (int i = 0; i < dungeons.length; i++) {
+            int required = dungeons[i][0]; // 최소 필요 피로도
+            int cost = dungeons[i][1]; // 소모 피로도
+
+            // 아직 방문 안 했고, 들어갈 수 있는 던전이면
+            if (!visited[i] && k >= required) {
+                visited[i] = true; // 방문 표시
+                dfs(k - cost, dungeons, count + 1); // 피로도 차감하고 다음 탐색
+                visited[i] = false; // 원상 복구 (백트래킹)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->

- 피로도  
- https://school.programmers.co.kr/learn/courses/30/lessons/87946

<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->

- 현재 피로도 k와 여러 개의 던전 정보가 주어진다.  
- 각 던전은 [최소 필요 피로도, 소모 피로도]로 표현된다.  
- 현재 피로도가 최소 필요 피로도 이상이어야 해당 던전에 입장할 수 있고, 입장 시 소모 피로도만큼 피로도가 감소한다.  
- 한 번 탐험한 던전은 다시 갈 수 없을 때, 입장 순서를 적절히 정해 탐험할 수 있는 던전의 최대 개수를 구하는 문제이다.

<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->

- 완전 탐색
- DFS(깊이 우선 탐색)
- 백트래킹

<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->

- 덕전 개수가 최대 8개이므로, 모든 순서를 직접 다 탐색하는 완전 탐색(DFS)으로 충분하다고 판단했다.
- visited[] 배열을 두어 현재까지 방문한 던전을 표시하고,  
  현재 피로도 k에서 아직 방문하지 않았고 k >= 최소 필요 피로도를 만족하는 던전들만 선택해서 재귀적으로 탐색했다.
- 던전에 입장할 수 있다면
  - visited[i] = true 로 표시 후  
  - 피로도를 k - 소모 피로도로 줄이고  
  - 탐험한 던전 개수를 count + 1로 증가시켜 DFS를 호출한다.
- 재귀 호출이 끝난 뒤에는 visited[i] = false로 되돌려서 다른 순서의 경우도 탐색할 수 있게 했다(백트래킹).
- 매 DFS 단계마다 현재까지 탐험한 개수 count 전역 변수 answer와 비교하여 최댓값을 갱신한다.
- 시간 복잡도는 던전 개수를 n이라 할 때 최악의 경우 O(n!)이지만, n ≤ 8이므로 제한 내에서 충분히 통과 가능하다.
