### PR TITLE
[프로그래머스] 17677 / 뉴스 클러스터링 - 해시 (Java)

### DIFF
--- a/solve/sanghoon/programmers/[17677] 뉴스 클러스터링.java
+++ b/solve/sanghoon/programmers/[17677] 뉴스 클러스터링.java
@@ -1,0 +1,62 @@
+import java.util.*;
+
+class Solution {
+    public int solution(String str1, String str2) {
+        // 대소문자 미구분 -> 대문자로 일괄 처리
+        str1 = str1.toUpperCase();
+        str2 = str2.toUpperCase();
+
+        // 각 문자열별 다중집합 생성 - 문자열:등장횟수
+        Map<String, Integer> map1 = new HashMap<>();
+        Map<String, Integer> map2 = new HashMap<>();
+
+        for (int i = 0; i < str1.length() - 1; i++) {
+            char a = str1.charAt(i);
+            char b = str1.charAt(i + 1);
+            if (Character.isLetter(a) && Character.isLetter(b)) {
+                String key = str1.substring(i, i + 2);
+                map1.merge(key, 1, Integer::sum);
+            }
+        }
+
+        for (int i = 0; i < str2.length() - 1; i++) {
+            char a = str2.charAt(i);
+            char b = str2.charAt(i + 1);
+            if (Character.isLetter(a) && Character.isLetter(b)) {
+                String key = str2.substring(i, i + 2);
+                map2.merge(key, 1, Integer::sum);
+            }
+        }
+
+        // 양쪽 모두 비어있는 경우 유사도는 1
+        if (map1.isEmpty() && map2.isEmpty()) {
+            return 1 * 65536;
+        }
+
+        // 한쪽만 비어있는 경우 유사도는 0
+        if (map1.isEmpty() || map2.isEmpty()) {
+            return 0;
+        }
+
+        // 유사도 계산을 위한 전체 키 집합 생성
+        Set<String> keys = new HashSet<>();
+        keys.addAll(map1.keySet());
+        keys.addAll(map2.keySet());
+
+        // 자카드 유사도 계산
+        int intersection = 0;
+        int union = 0;
+
+        for (String key : keys) {
+            int v1 = map1.getOrDefault(key, 0);
+            int v2 = map2.getOrDefault(key, 0);
+
+            intersection += Math.min(v1, v2);
+            union += Math.max(v1, v2);
+        }
+
+        double jaccard = (double) intersection / union;
+
+        return (int) (jaccard * 65536);
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
뉴스 클러스터링
https://school.programmers.co.kr/learn/courses/30/lessons/17677
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
주어진 두 문자열을 기준에 따라 집합으로 만든 뒤 자카드 유사도를 계산하는 문제
- 문자열을 두 글자씩 끊어서 다중집합을 만든다. 이때 영문자로 된 글자 쌍만 유효하고, 기타 공백이나 숫자, 특수 문자가 들어있는 경우는 그 글자 쌍을 버린다. 또한 다중집합 원소 사이를 비교할 때 대소문자는 무시한다.
- 두 집합 사이의 자카드 유사도는 (교집합 크기/합집합 크기)로 정의된다.
<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
문자열 파싱
해시
<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
1. 각 문자열마다 다중집합을 생성합니다. 문제에서 대소문자 구분을 하지 않으므로 대문자로 통일합니다. 다중집합은 글자쌍을 키(key)로, 등장횟수를 값(value)으로 갖는 해시맵을 통해 표현합니다.
2. 두 집합의 교집합, 합집합을 구해 자카드 유사도를 계산합니다.
    - 자카드 유사도를 구하려면 교집합, 합집합의 크기가 필요합니다.
    - 교집합, 합집합을 직접 생성할 수도 있지만, 이번에는 교집합, 합집합의 크기만 구하는 방법을 사용했습니다.
    - 두 집합의 전체 글자쌍 목록을 구하고, 이를 이용해 교집합, 합집합의 크기를 직접 계산합니다.

- 시간복잡도는 해시 충돌 상황을 제외하면 `O(n)` 입니다.