### PR TITLE
[프로그래머스] 132265 / 롤케이크 자르기

### DIFF
--- a/solve/hyunseung/programmers/[132265] 롤케이크 자르기.java
+++ b/solve/hyunseung/programmers/[132265] 롤케이크 자르기.java
@@ -1,0 +1,44 @@
+class Solution {
+    public int solution(int[] topping) {
+        int maxType = 10000; // 토핑 번호 최대
+        int[] left = new int[maxType + 1];
+        int[] right = new int[maxType + 1];
+
+        int rightKinds = 0;
+        int leftKinds = 0;
+
+        // 1. 처음에는 모든 조각이 "오른쪽"에 있다고 보고 종류 수 세기
+        for (int t : topping) {
+            if (right[t] == 0) {
+                rightKinds++;
+            }
+            right[t]++;
+        }
+
+        int answer = 0;
+
+        // 2. 왼쪽으로 하나씩 옮겨가며 비교 (마지막 조각 직전까지만)
+        for (int i = 0; i < topping.length - 1; i++) {
+            int t = topping[i];
+
+            // t를 오른쪽에서 하나 빼기
+            right[t]--;
+            if (right[t] == 0) {
+                rightKinds--;
+            }
+
+            // t를 왼쪽에 하나 추가
+            if (left[t] == 0) {
+                leftKinds++;
+            }
+            left[t]++;
+
+            // 3. 종류 수가 같으면 공평하게 자른 위치
+            if (leftKinds == rightKinds) {
+                answer++;
+            }
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
롤케이크 자르기  
https://school.programmers.co.kr/learn/courses/30/lessons/132265

---

## 문제 요약
토핑 배열이 주어졌을 때, 케이크를 한 지점에서 잘라  
왼쪽과 오른쪽 조각에 포함된 서로 다른 토핑 종류 수가 동일한 횟수를 구하는 문제입니다.

---

## 사용 알고리즘
- Counting Array (카운팅 배열)
- 단방향 스캔(투 포인터 느낌)
- 시간 복잡도: O(N)

---

## 풀이 해설

### 1) 비효율적 초기 접근
처음에는 각 지점에서 HashSet으로 왼쪽, 오른쪽의 서로 다른 토핑 개수를 계산하려 했습니다.  
그러나 매 지점마다 O(N) 연산이 필요해 전체 O(N^2)로 시간 초과가 발생합니다.

---

### 2) 효율적 해결 방법 (핵심 아이디어)
문제를 O(N)으로 해결하기 위해 변화량만 갱신하는 방식을 사용했습니다.

#### (1) 초기 작업
- 모든 토핑을 "오른쪽 영역"에 있다고 가정합니다.
- right[] 배열로 토핑 개수를 세고  
  오른쪽에 존재하는 "서로 다른 토핑 종류 수(rightKinds)"를 구해둡니다.

#### (2) 왼쪽으로 하나씩 이동하며 토핑 상태 갱신
인덱스를 0부터 끝까지 이동하며 매번 토핑 하나를 오른쪽에서 왼쪽으로 옮긴다고 가정합니다.

- right[t]--  값이 0이 되면 rightKinds--  
- left[t]++   값이 0에서 1이 되면 leftKinds++

이 모든 처리는 배열 접근이라 O(1)입니다.

#### (3) 공평한 지점 판별
매 위치에서  
leftKinds == rightKinds  
이면 공평하게 나눌 수 있는 지점이므로 정답을 1 증가시킵니다.

---

### 3) 시간 복잡도
- 초기 전체 카운팅: O(N)  
- 한 번의 단방향 스캔: O(N)  
- 전체 시간 복잡도: O(N)

---

## 최종 요약
- HashSet을 매번 사용해 전체를 다시 계산하는 방식은 O(N^2)로 시간 초과  
- 카운팅 배열 기반의 "변화량 갱신 방식"으로 O(N)에 해결  
- 핵심은 매 지점마다 전체를 다시 세지 않고, 이동한 토핑만 업데이트하는 것입니다.
