### PR TITLE
[프로그래머스] 42584 주식가격 - 스택/큐 (Java)

### DIFF
--- a/solve/hyunseung/programmers/[42584] 주식가격.java
+++ b/solve/hyunseung/programmers/[42584] 주식가격.java
@@ -1,0 +1,26 @@
+import java.util.*;
+
+class Solution {
+    public int[] solution(int[] prices) {
+        int n = prices.length;
+        int[] answer = new int[n];
+        Deque<Integer> stack = new ArrayDeque<>(); // 인덱스 스택
+
+        for (int i = 0; i < n; i++) {
+            // 현재 가격이 스택 top 시점의 가격보다 낮아지는 순간 => 그 시점 정답 확정
+            while (!stack.isEmpty() && prices[i] < prices[stack.peek()]) {
+                int idx = stack.pop();
+                answer[idx] = i - idx;
+            }
+            stack.push(i);
+        }
+
+        // 끝까지 가격이 떨어지지 않은 애들 처리
+        while (!stack.isEmpty()) {
+            int idx = stack.pop();
+            answer[idx] = (n - 1) - idx;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
주식가격 (42584)

링크: 프로그래머스 스택/큐 > 주식가격
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
초 단위로 기록된 주식가격 배열 prices가 주어질 때, 각 시점 i에 대해 이후로 가격이 처음 떨어지기 전까지(가격이 떨어지지 않는 동안) 유지되는 시간(초)을 구해 배열로 반환합니다.
끝까지 가격이 떨어지지 않으면 마지막 시점까지의 시간을 반환합니다.
<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
스택(모노토닉 스택 / 인덱스 스택)

배열 순회(선형 탐색)
<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
1) 접근 방식

처음 떠올리기 쉬운 방식은 각 시점 i마다 i+1부터 끝까지 확인하며 prices[j] < prices[i]가 되는 순간을 찾는 이중 반복문(O(n²))입니다.
하지만 prices 길이가 최대 100,000이므로 O(n²)은 시간 초과 가능성이 매우 큽니다.

그래서 관점을 바꿔 정답이 확정되는 순간을 이용합니다.
어떤 시점 idx의 가격은, 이후 시점 i에서 prices[i] < prices[idx]가 되는 순간에 처음으로 하락이 발생하므로 그때 정답이 i - idx로 확정됩니다.

이를 위해 "아직 하락을 만나지 못해 정답이 확정되지 않은 인덱스들"을 스택에 저장해두고, 새로운 가격이 들어올 때마다 스택의 top과 비교하여 하락이 발생한 인덱스들의 정답을 연쇄적으로 확정합니다.

2) 알고리즘 동작 방식(핵심 로직)

스택에는 인덱스를 저장합니다. (시간 차이 계산을 위해)

배열을 왼쪽부터 오른쪽으로 순회하며, 현재 인덱스를 i라고 할 때:

스택이 비어있지 않고 prices[i] < prices[stackTop]이면
스택 top 인덱스는 지금 시점에 처음 가격이 떨어진 것이므로
answer[stackTop] = i - stackTop으로 확정하고 pop합니다.

이 과정을 더 이상 떨어지지 않을 때까지 반복합니다(while).

이후 현재 인덱스 i를 스택에 push합니다.

순회가 끝난 뒤에도 스택에 남아있는 인덱스들은 끝까지 가격이 떨어지지 않은 경우이므로
answer[idx] = (n - 1) - idx로 채웁니다.

3) 시행착오/주의 포인트

하락 조건은 prices[i] < prices[stackTop] 입니다.
같은 가격은 "떨어진 것"이 아니기 때문에 <=가 아니라 <를 사용해야 합니다.

끝까지 떨어지지 않은 값 처리(마지막 while)가 빠지면 오답이 됩니다.

연쇄적으로 여러 인덱스가 한 번에 정답 확정될 수 있어 if가 아니라 while이 필요합니다.

4) 시간/공간 복잡도

시간 복잡도: O(n)
각 인덱스는 스택에 최대 1번 push, 1번 pop만 되므로 전체 연산이 선형입니다.

공간 복잡도: O(n)
최악의 경우 스택에 n개가 쌓일 수 있습니다.