### PR TITLE
[프로그래머스] 42888 / 오픈채팅방(Java)

### DIFF
--- a/solve/hyunseung/programmers/[42888] 오픈채팅방.java
+++ b/solve/hyunseung/programmers/[42888] 오픈채팅방.java
@@ -1,0 +1,37 @@
+import java.util.*;
+
+class Solution {
+    public String[] solution(String[] record) {
+        // 1. 유저 아이디별 최신 닉네임을 저장할 맵
+        Map<String, String> nicknameMap = new HashMap<>();
+        // 2. 출력할 메시지 정보를 담을 리스트 (유저아이디, 행동)
+        List<String[]> log = new ArrayList<>();
+
+        for (String r : record) {
+            String[] parts = r.split(" ");
+            String action = parts[0]; // Enter, Leave, Change
+            String userId = parts[1];
+
+            if (action.equals("Enter")) {
+                String nickname = parts[2];
+                nicknameMap.put(userId, nickname); // 닉네임 업데이트 또는 삽입
+                log.add(new String[]{userId, "님이 들어왔습니다."});
+            } else if (action.equals("Leave")) {
+                log.add(new String[]{userId, "님이 나갔습니다."});
+            } else if (action.equals("Change")) {
+                String nickname = parts[2];
+                nicknameMap.put(userId, nickname); // 닉네임 변경
+            }
+        }
+
+        // 3. 로그 리스트를 순회하며 최종 닉네임으로 메시지 조립
+        String[] answer = new String[log.size()];
+        for (int i = 0; i < log.size(); i++) {
+            String userId = log.get(i)[0];
+            String message = log.get(i)[1];
+            answer[i] = nicknameMap.get(userId) + message;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
프로그래머스 링크: https://school.programmers.co.kr/learn/courses/30/lessons/42888
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
채팅방에 들어오고 나가는 유저들의 기록이 주어질 때, 최종적으로 보여질 메시지 로그를 출력하는 문제입니다.

닉네임 변경 방식: 채팅방 내에서 변경하거나, 나간 후 새로운 닉네임으로 다시 들어오는 두 가지 방식이 있습니다.

핵심 조건: 닉네임이 변경되면 기존에 출력되었던 메시지의 닉네임도 모두 최신으로 업데이트되어야 합니다.

고유값: 유저는 고유한 [유저 아이디]로 구분됩니다.
<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
해시맵 (HashMap): 유저 아이디(Key)와 최신 닉네임(Value)을 매핑하여 관리합니다.

구현/시뮬레이션: 주어진 기록을 순차적으로 처리합니다.
<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
핵심 아이디: 닉네임은 변하지만 유저 아이디는 고유하다는 점을 이용해 2단계로 나누어 처리합니다.

1단계 (닉네임 확정): 전체 기록을 순회하며 Enter와 Change 발생 시 해당 아이디의 최신 닉네임을 맵에 저장합니다. 루프가 끝나면 맵에는 각 아이디별 최종 닉네임만 남습니다.

2단계 (메시지 생성): 기록을 다시 순회하며 Enter와 Leave에 대해 맵에서 최종 닉네임을 찾아 메시지를 완성합니다. Change는 무시합니다.