### PR TITLE
[프로그래머스] 77885 / 2개 이하로 다른 비트 - 비트 연산 (Java)

### DIFF
--- a/solve/sanghoon/programmers/[77885] 2개 이하로 다른 비트.java
+++ b/solve/sanghoon/programmers/[77885] 2개 이하로 다른 비트.java
@@ -1,0 +1,14 @@
+class Solution {
+    public long[] solution(long[] numbers) {
+        long[] answer = new long[numbers.length];
+
+        for (int i = 0; i < numbers.length; i++) {
+            long n = numbers[i];
+            int trailingOnes = Long.numberOfTrailingZeros(~n);
+            int k = trailingOnes > 1 ? trailingOnes - 1 : 0;
+            answer[i] = n + (1L << k);
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
2개 이하로 다른 비트
https://school.programmers.co.kr/learn/courses/30/lessons/77885
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
주어진 양의 정수 n에 대해서, n보다 크고 n과 비트가 2개 이하로 다른 수들 중에서 가장 작은 수를 구하는 문제

<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
비트 연산

<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- n의 LSB부터 연속된 1의 개수가 x개 일 때, x번째 비트에 1을 더한 수가 비트가 2개 이하로 다른 가장 작은 수가 됩니다.
  - 예를 들어, 23=`10111`은 연속된 1의 개수가 3개이고, 3번째 비트에 1을 더한 `11011`=27이 비트가 2개 이하로 다른 가장 작은 수 입니다.
- 즉, `n + (1 << (x - 1))`이 비트가 2개 이하로 다른 수들 중에서 가장 작은 수가 됩니다.
- x-1이 음수가 되는 경우(n이 짝수인 경우)를 별도로 처리하기 위해 k를 따로 계산했습니다(n이 짝수인 경우 k=0이고, n+1이 정답이 됩니다).
- 시간복잡도: `O(n)`
  - `Long.numberOfTrailingZeros()`는 비트 연산으로 `O(1)`으로 동작합니다.
