### PR TITLE
[프로그래머스] 152996 / 시소짝꿍 (Java)

### DIFF
--- a/solve/hyunseung/programmers/[152996] 시소짝꿍.java
+++ b/solve/hyunseung/programmers/[152996] 시소짝꿍.java
@@ -1,0 +1,27 @@
+import java.util.*;
+
+class Solution {
+    public long solution(int[] weights) {
+        long answer = 0;
+        Arrays.sort(weights); // 오름차순 정렬
+        Map<Double, Integer> map = new HashMap<>();
+        
+        for (int w : weights) {
+            double a = w * 1.0;
+            double b = (w * 2.0) / 3.0;
+            double c = (w * 1.0) / 2.0;
+            double d = (w * 3.0) / 4.0;
+            
+            // 현재 몸무게와 짝꿍이 될 수 있는 비율들이 이전에 있었는지 확인
+            if (map.containsKey(a)) answer += map.get(a);
+            if (map.containsKey(b)) answer += map.get(b);
+            if (map.containsKey(c)) answer += map.get(c);
+            if (map.containsKey(d)) answer += map.get(d);
+            
+            // 현재 몸무게 빈도수 업데이트
+            map.put(a, map.getOrDefault(a, 0) + 1);
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/152996
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
시소의 중심으로부터 2m, 3m, 4m 지점에 좌석이 있습니다. 두 사람이 각각의 좌석에 앉았을 때 (몸무게 × 거리)의 값이 양쪽 모두 같다면 '시소 짝꿍'입니다. 사람들의 몸무게 목록 weights가 주어질 때, 시소 짝꿍이 몇 쌍 존재하는지 구하는 문제입니다.


<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
- 정렬 (Sorting): 데이터를 순차적으로 처리하기 위해 사용합니다.
- 해시 (HashMap / Array Counting): 몸무게별 빈도수를 저장하여 중복 계산을 피하기 위해 사용합니다.
<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- 몸무게 정렬: 먼저 weights를 오름차순으로 정렬합니다. 작은 몸무게부터 순차적으로 탐색하면 비율 계산이 단순해집니다.
- 비율 계산: 시소가 평형을 이루는 비율은 1:1, 2:3, 2:4(1:2), 3:4 총 네 가지 케이스뿐입니다.
- 카운팅: 각 몸무게를 확인하며 이전에 탐색한 사람들 중 시소 짝꿍이 될 수 있는 비율의 몸무게가 몇 명 있었는지 해시에 저장된 값을 불러와 정답에 더해줍니다.
- 시간복잡도: O(n log n)
 배열을 정렬하는 데 $O(n \log n)$이 소요됩니다.
 몸무게 목록을 한 번 순회하며 해시맵에서 값을 찾는 과정은 $O(n)$입니다.
 전체적으로 $n=100,000$일 때 충분히 안정적으로 통과 가능합니다.