### PR TITLE
[프로그래머스] 389479 / 서버 증설 횟수 - 큐 (Java)

### DIFF
--- a/solve/sanghoon/programmers/[389479] 서버 증설 횟수.java
+++ b/solve/sanghoon/programmers/[389479] 서버 증설 횟수.java
@@ -1,0 +1,27 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[] players, int m, int k) {
+        int answer = 0;
+        int time = 0;
+        Queue<Integer> server = new ArrayDeque<>(); // 서버 반납 시간을 저장
+
+        for (int player : players) {
+            // 운영 시간이 지난 서버 반납
+            while (!server.isEmpty() && server.peek() <= time) {
+                server.poll();
+            }
+
+            // 필요한 서버 수 계산 후 부족한 서버 추가
+            int additionalServer = player / m;
+            while (server.size() < additionalServer) {
+                server.offer(time + k);
+                answer++;
+            }
+
+            time++;
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
서버 증설 횟수
https://school.programmers.co.kr/learn/courses/30/lessons/389479

<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
게임에 유저가 `m`명 늘어날 때마다 서버 한대를 추가해야 한다. 즉, 어느 시간대의 이용자가 `n * m`명 이상 `(n + 1) * m`명 미만이라면, 서버가 최소 `n`대 추가되어 있어야 한다.
한번 추가한 서버는 `k`시간 후에 반납한다.
00시부터 24시까지 시간별로 하루의 게임 이용자 수가 주어질 때, 서버를 최소 몇 번 증설했는지 구하는 문제

<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
큐

<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- 현재 증설된 서버를 큐를 통해 기록합니다.
- 각 시간별로 현재 서버의 수와 필요한 서버 수의 최솟값을 비교하여, 증설이 필요한 경우 큐에 서버를 추가하고 증설 횟수를 기록합니다.
- 시간복잡도: `O(n)`
  - 반복문은 수행 횟수가 24회로 고정이며(`O(1)`), 서버의 경우 최대 S회 삽입과 삭제가 일어나므로 `O(2S)`입니다. 따라서 정리하면 전체 시간복잡도는 `O(n)`이 됩니다.