### PR TITLE
[프로그래머스] 17683 / 방금그곡 - 구현 (Java)

### DIFF
--- a/solve/sanghoon/programmers/[17683] 방금그곡.java
+++ b/solve/sanghoon/programmers/[17683] 방금그곡.java
@@ -1,0 +1,80 @@
+import java.util.*;
+import java.util.regex.*;
+
+class Solution {
+    public String solution(String m, String[] musicinfos) {
+        String answer = "(None)";
+        int maxTime = 0;
+        List<String> pattern = parseMelody(m);
+
+        for (String musicinfo : musicinfos) {
+            String[] infos = musicinfo.split(",");
+
+            int start = parseTime(infos[0]);
+            int end = parseTime(infos[1]);
+            int playTime = end - start;
+
+            String name = infos[2];
+
+            List<String> base = parseMelody(infos[3]);
+            List<String> totalMelody = totalMelody(base, playTime);
+
+            if (containsMelody(totalMelody, pattern) && playTime > maxTime) {
+                maxTime = playTime;
+                answer = name;
+            }
+        }
+
+        return answer;
+    }
+
+    private int parseTime(String time) {
+        String[] times = time.split(":");
+        int hour = Integer.parseInt(times[0]);
+        int minute = Integer.parseInt(times[1]);
+
+        return hour * 60 + minute;
+    }
+
+    private List<String> parseMelody(String melody) {
+        List<String> result = new ArrayList<>();
+
+        Pattern pattern = Pattern.compile("[A-G]#?");
+        Matcher matcher = pattern.matcher(melody);
+
+        while (matcher.find()) {
+            result.add(matcher.group());
+        }
+
+        return result;
+    }
+
+    private List<String> totalMelody(List<String> base, int playTime) {
+        List<String> totalMelody = new ArrayList<>();
+        int melodyLength = base.size();
+
+        for (int i = 0; i < playTime; i++) {
+            totalMelody.add(base.get(i % melodyLength));
+        }
+
+        return totalMelody;
+    }
+
+    private boolean containsMelody(List<String> target, List<String> pattern) {
+        for (int i = 0; i <= target.size() - pattern.size(); i++) {
+            boolean matched = true;
+            for (int j = 0; j < pattern.size(); j++) {
+                if (!target.get(i + j).equals(pattern.get(j))) {
+                    matched = false;
+                    break;
+                }
+            }
+
+            if (matched) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
방금그곡
https://school.programmers.co.kr/learn/courses/30/lessons/17683

<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
주어진 멜로디(`m`)을 포함하고 있는 음악의 제목을 찾는 문제
- 음악 정보는 곡의 재생 시작/종료 시각, 곡의 제목, 곡의 원래 멜로디 형태로 주어진다.
- 곡의 멜로디 보다 재생 시간이 긴 경우 반복 재생하는 것으로 취급한다.
- 일치하는 곡이 여러 개일 때는 재생 시간이 가장 긴 곡 제목을 반환한다.

<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
문자열 파싱
구현

<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
1. 멜로디를 음 단위로 분리합니다. 
2. 곡의 재생 시간과 원래 멜로디를 통해 실제로 재생된 `totalMelody`를 구합니다.
3. `totalMelody`에 주어진 멜로디가 포함되어 있는지 검사합니다. 검사에는 슬라이딩 윈도우 방식을 활용했습니다.
4. 조건을 만족하는 가장 재생시간이 긴 음악의 제목을 반환합니다.

- 처음에는 단순히 문자열을 이어붙여서 `contains()` 메서드를 이용해 검사했는데, 이 경우에 #이 붙은 음에 대해 제대로 동작하지 않는 문제가 있었습니다(예: `totalMelody = "ABC#"`, `m = "BC"` 인 경우 조건을 만족하지 않지만 `contains()`는 `true`를 반환합니다).
- 그래서 각 음을 분리해서 `List`에 담아 비교하는 방식을 사용했습니다. 이때 음을 분리하기 위해 정규표현식 `[A-G]#?`을 사용했습니다.
- 시간복잡도: `O(NML)` (N: 곡의 개수, L: 재생 시간, M: 기억한 멜로디(`m`) 길이)