### PR TITLE
[프로그래머스] 81032 / 거리두기 확인하기.Java

### DIFF
--- a/solve/hyunseung/programmers/[81032] 거리두기 확인하기.java
+++ b/solve/hyunseung/programmers/[81032] 거리두기 확인하기.java
@@ -1,0 +1,63 @@
+import java.util.*;
+
+class Solution {
+    // 상하좌우 이동을 위한 좌표
+    int[] dx = {-1, 1, 0, 0};
+    int[] dy = {0, 0, -1, 1};
+
+    public int[] solution(String[][] places) {
+        int[] answer = new int[5];
+
+        for (int i = 0; i < 5; i++) {
+            if (checkRoom(places[i])) answer[i] = 1;
+            else answer[i] = 0;
+        }
+        return answer;
+    }
+
+    private boolean checkRoom(String[] room) {
+        for (int r = 0; r < 5; r++) {
+            for (int c = 0; c < 5; c++) {
+                // 응시자가 앉아있는 위치에서 BFS 시작
+                if (room[r].charAt(c) == 'P') {
+                    if (!bfs(room, r, c)) return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private boolean bfs(String[] room, int r, int c) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.offer(new int[]{r, c, 0});
+        boolean[][] visited = new boolean[5][5];
+        visited[r][c] = true;
+
+        while (!queue.isEmpty()) {
+            int[] curr = queue.poll();
+            
+            // 거리가 2인 지점까지만 확인하면 됨
+            if (curr[2] >= 2) continue;
+
+            for (int i = 0; i < 4; i++) {
+                int nr = curr[0] + dx[i];
+                int nc = curr[1] + dy[i];
+
+                if (nr >= 0 && nr < 5 && nc >= 0 && nc < 5 && !visited[nr][nc]) {
+                    // 파티션을 만나면 그 방향은 탐색 중단
+                    if (room[nr].charAt(nc) == 'X') continue;
+                    
+                    // 빈 테이블이면 탐색 계속 (거리 1 추가)
+                    if (room[nr].charAt(nc) == 'O') {
+                        visited[nr][nc] = true;
+                        queue.offer(new int[]{nr, nc, curr[2] + 1});
+                    }
+                    
+                    // 다른 응시자를 만나면 거리두기 위반
+                    if (room[nr].charAt(nc) == 'P') return false;
+                }
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
거리두기 확인하기: https://school.programmers.co.kr/learn/courses/30/lessons/81302
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
5개의 $5 \times 5$ 크기 대기실에서 응시자들이 거리두기 규칙을 잘 지키고 있는지 확인하는 문제입니다.
- 거리두기 규칙: 응시자(P) 간의 맨해튼 거리가 2 이하여야 합니다.
- 예외 조건: 두 응시자 사이가 파티션(X)으로 완전히 막혀 있는 경우에는 허용됩니다.
- 빈 테이블(O): 비어 있는 공간으로, 이 공간을 통해 옆 사람에게 접근할 수 있다면 거리두기 위반입니다.
- 결과 반환: 각 대기실별로 거리두기를 지켰으면 1, 한 명이라도 어겼으면 0을 담은 배열을 반환합니다.
<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
- BFS (너비 우선 탐색): 각 응시자(P)의 위치를 시작점으로 하여 거리가 2 이내인 범위만 탐색합니다. 파티션(X)을 만나면 더 이상 탐색하지 않는 방식으로 벽을 구현할 수 있습니다.
<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- 전체 순회: 5개의 대기실을 하나씩 확인하며, 각 대기실에서 응시자('P')가 앉아 있는 모든 좌표를 찾습니다.
- BFS 탐색: 응시자 위치에서 상하좌우로 탐색을 시작합니다.
 1. 거리 제한: 거리가 2를 초과하면 더 이상 탐색하지 않습니다.
 2. 파티션(X) 처리: 탐색 중 파티션을 만나면 해당 방향으로는 거리두기 위반 가능성이 없으므로 탐색을 중단합니다.
 3. 위반 사례: 탐색 중 거리가 2 이하인데 다른 응시자('P')를 만난다면 즉시 해당 대기실은 거리두기 실패(0)로 간주합니다.