### PR TITLE
[프로그래머스] 172927 / 광물 캐기 - 그리디 (Java)

### DIFF
--- a/solve/sanghoon/programmers/[172927] 광물 캐기.java
+++ b/solve/sanghoon/programmers/[172927] 광물 캐기.java
@@ -1,0 +1,63 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int[] picks, String[] minerals) {
+        // 캘 수 있는 최대 그룹 수 계산
+        // 총 곡괭이의 수와 mineral을 5개씩 묶은 그룹의 수 중 작은 값
+        int size = Math.min(picks[0] + picks[1] + picks[2], (minerals.length + 4) / 5);
+
+        // 광물을 5개씩 순서대로 묶어서 그릅화 -> 정렬
+        PriorityQueue<Group> groups = new PriorityQueue<>();
+
+        for (int i = 0; i < size; i++) {
+            Group g = new Group();
+
+            int l = Math.min((i + 1) * 5, minerals.length);
+            for (int j = i * 5; j < l; j++) {
+                switch (minerals[j]) {
+                    case "diamond" -> g.diamond++;
+                    case "iron" -> g.iron++;
+                    case "stone" -> g.stone++;
+                }
+            }
+
+            groups.offer(g);
+        }
+
+        // 그리디 알고리즘
+        int answer = 0;
+        for (Group g : groups) {
+            int diamond = g.diamond;
+            int iron = g.iron;
+            int stone = g.stone;
+
+            if (picks[0] > 0) {
+                answer += diamond + iron + stone;
+                picks[0]--;
+            } else if (picks[1] > 0) {
+                answer += diamond * 5 + iron + stone;
+                picks[1]--;
+            } else if (picks[2] > 0) {
+                answer += diamond * 25 + iron * 5 + stone;
+                picks[2]--;
+            }
+        }
+
+        return answer;
+    }
+
+    static class Group implements Comparable<Group> {
+        int diamond;
+        int iron;
+        int stone;
+
+        @Override
+        public int compareTo(Group o) { // 다이아가 많은 순 -> 철이 많은 순으로 정렬
+            if (this.diamond != o.diamond) {
+                return Integer.compare(o.diamond, this.diamond);
+            }
+
+            return Integer.compare(o.iron, this.iron);
+        }
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
광물 캐기
https://school.programmers.co.kr/learn/courses/30/lessons/172927

<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
다이아몬드, 철, 돌의 3 종류의 곡괭이와 광물이 존재한다.
각 곡괭이로 광물을 캘 때 발생하는 피로도는 아래와 같다.
|곡괭이|다이아몬드|철|돌|
|---|:---:|:---:|:---:|
|다이아 곡괭이|1|1|1|
|철 곡괭이|5|1|1|
|돌 곡괭이|25|5|1|

곡괭이 순서는 자유롭게 선택할 수 있으나 한번 선택한 곡괭이는 5개의 광물을 연속으로 캔 후 사라지며, 광물은 주어진 순서대로 캐야 한다. 곡괭이를 전부 사용하거나 광물을 다 캘 경우 작업이 종료된다.
작업이 종료될 때 발생하는 피로도의 최솟값을 구하는 문제


<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
그리디 알고리즘

<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- 그리디 알고리즘과 dp 알고리즘 중 조금 더 효율적인 그리디 알고리즘을 선택했습니다.

1. 계산의 편의를 위해 먼저 실제로 캐는 광물 그룹의 수를 구합니다.
2. 광물을 순서대로 5개씩 묶어 그룹을 만든 뒤, 다이아몬드->철이 많은 순으로 정렬합니다.
3. 다이아->철->돌 곡괭이 순서대로 사용하여 광물 그룹을 캐서 발생하는 피로도를 구합니다.

- 시간복잡도: `O(N logN)`
  - 광물 그룹 생성 + 정렬에 `O(N) * O(logN)`
  - 피로도 계산에 `O(N/5)`
  - 따라서 전체 시간복잡도는 `O(N logN)`