### PR TITLE
[프로그래머스] 42890 / 후보키 (Java)

### DIFF
--- a/solve/hyunseung/programmers/[42890] 후보키.java
+++ b/solve/hyunseung/programmers/[42890] 후보키.java
@@ -1,0 +1,49 @@
+import java.util.*;
+
+class Solution {
+    public int solution(String[][] relation) {
+        int rowLen = relation.length;
+        int colLen = relation[0].length;
+        List<Integer> candidateKeys = new ArrayList<>();
+
+        // 1. 모든 컬럼 조합을 비트마스크로 탐색 (1부터 2^colLen - 1까지)
+        for (int i = 1; i < (1 << colLen); i++) {
+            // 2. 최소성 검사
+            if (!isMinimal(i, candidateKeys)) continue;
+
+            // 3. 유일성 검사
+            if (isUnique(i, relation, rowLen, colLen)) {
+                candidateKeys.add(i);
+            }
+        }
+
+        return candidateKeys.size();
+    }
+
+    private boolean isUnique(int mask, String[][] relation, int rowLen, int colLen) {
+        Set<String> set = new HashSet<>();
+
+        for (int r = 0; r < rowLen; r++) {
+            StringBuilder sb = new StringBuilder();
+            for (int c = 0; c < colLen; c++) {
+                // mask의 c번째 비트가 1인지 확인
+                if ((mask & (1 << c)) != 0) {
+                    sb.append(relation[r][c]).append("/"); // 구분자 추가
+                }
+            }
+            set.add(sb.toString());
+        }
+
+        return set.size() == rowLen;
+    }
+
+    private boolean isMinimal(int mask, List<Integer> candidateKeys) {
+        for (int key : candidateKeys) {
+            // 이미 저장된 후보키(key)가 현재 조합(mask)에 완전히 포함되는지 확인
+            if ((key & mask) == key) {
+                return false;
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
문제: https://school.programmers.co.kr/learn/courses/30/lessons/42890
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
- 주어진 표에서 후보키의 최대 개수를 구하는 문제입니다. 후보키가 되기 위해서는 다음 두 가지 조건을 만족해야 합니다.
1.  유일성(Uniqueness): 릴레이션에 있는 모든 튜플(행)을 유일하게 식별할 수 있어야 합니다.
2. 최소성(Minimality): 꼭 필요한 속성들로만 구성되어야 합니다. 즉, 후보키를 구성하는 속성 중 하나라도 제외하면 유일성이 깨져야 합니다.
<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
- 비트마스크 (Bitmask): 컬럼의 조합을 선택할 때 사용합니다. 컬럼이 최대 8개이므로 $2^8 = 256$가지 경우의 수만 고려하면 됩니다.
- 브루트포스 (Brute-force): 모든 가능한 컬럼 조합을 탐색합니다.
<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- 컬럼 조합 생성 (비트마스크): 컬럼이 4개라면 0001(1번 컬럼), 1011(1, 2, 4번 컬럼)과 같이 1부터 $2^{col\_count}-1$까지의 이진수로 모든 조합을 표현할 수 있습니다.
- 유일성 검사: 선택된 컬럼 조합의 값들을 하나의 문자열로 합쳐 HashSet에 넣습니다. Set의 크기가 전체 행의 개수와 같다면 모든 행이 구분되는 것이므로 유일성을 만족합니다.
- 최소성 검사: 이미 찾은 후보키 리스트를 순회하며, 현재 유일성을 만족한 조합이 기존 후보키를 포함하고 있는지 확인합니다. 비트 연산 (candidateKey & currentKey) == candidateKey를 통해 쉽게 확인할 수 있습니다.
- 시간복잡도: $O(2^C \times R \times C)$: $C$: 컬럼 수(최대 8), $R$: 행 수(최대 20). 조합의 수가 매우 적어 브루트포스로 충분히 해결 가능합니다.