### PR TITLE
[프로그래머스] 468372 / 리프 노드 수 최적화 - DFS(Java)

### DIFF
--- a/solve/JangJiwon/programmers/[468372]리프노드수최적화.java
+++ b/solve/JangJiwon/programmers/[468372]리프노드수최적화.java
@@ -1,0 +1,46 @@
+class Solution {
+    int maxLeaves = 1;
+    
+    public int solution(int dist_limit, long split_limit) {
+        dfs(1, 0, 1, dist_limit, split_limit);
+        return maxLeaves;
+    }
+    
+    void dfs(long nodes, int distUsed, long product, 
+             int distLimit, long splitLimit) {
+        // 현재까지의 리프 노드 수 갱신
+        maxLeaves = Math.max(maxLeaves, (int) Math.min(nodes, Integer.MAX_VALUE));
+
+        // 종료 
+        if (distUsed >= distLimit) return;
+        
+        // 남은 분배 노드로 확장 가능한 최대치 계산
+        long canExpand = Math.min(nodes, distLimit - distUsed);
+        
+        if (canExpand < nodes) {
+            // 일부만 확장 (마지막 레벨)
+            long remain = nodes - canExpand;
+            
+            if (product * 2 <= splitLimit) {
+                maxLeaves = Math.max(maxLeaves, 
+                    (int) Math.min(remain + canExpand * 2, Integer.MAX_VALUE));
+            }
+            if (product * 3 <= splitLimit) {
+                maxLeaves = Math.max(maxLeaves, 
+                    (int) Math.min(remain + canExpand * 3, Integer.MAX_VALUE));
+            }
+            return;
+        }
+        
+        // 모두 확장
+        if (product * 2 <= splitLimit) {
+            dfs(nodes * 2, distUsed + (int)nodes, product * 2, 
+                distLimit, splitLimit);
+        }
+        
+        if (product * 3 <= splitLimit) {
+            dfs(nodes * 3, distUsed + (int)nodes, product * 3, 
+                distLimit, splitLimit);
+        }
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
리프 노드 수 최적화 
https://school.programmers.co.kr/learn/courses/30/lessons/468372
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
제약 조건 하에서 트리를 구성하여 리프 노드를 최대한 많이 만들기
<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
DFS, 완전탐색, 그리디
<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- 각 깊이에서 자식을 2개 또는 3개 선택
- 분배도 = 각 깊이 자식 수의 곱 ≤ split_limit
- 리프 노드 수 = 마지막 깊이의 총 노드 수
- 종료조건 : 
product > splitLimit면 중단
depth > distLimit면 중단
- 모든 노드 확장 시도는 실패
일부 노드를 리프로 남기는 것을 고려하지 않아 실패
- 레벨당 분배 노드 1개만 추가하는 시도 실패
나머지 노드를 리프로 남기는 것을 고려하지 않아 실패
- expand를 1~nodes까지 전부 시도
불필요한 중복 탐색으로 시간 초과
- 모두 확장 OR 최대한 확장만 고려
expand 루프 제거
- 시간 복잡도 : O(2^depth)