### PR TITLE
[프로그래머스] 86052 / 아날로그 시계 (Java)

### DIFF
--- a/solve/hyunseung/programmers/[250135] 아날로그 시계.java
+++ b/solve/hyunseung/programmers/[250135] 아날로그 시계.java
@@ -1,0 +1,42 @@
+class Solution {
+    public int solution(int h1, int m1, int s1, int h2, int m2, int s2) {
+        int answer = 0;
+
+
+        int start = h1 * 3600 + m1 * 60 + s1;
+        int end = h2 * 3600 + m2 * 60 + s2;
+
+        
+        if (start % 43200 == 0 || (start * 720) % 43200 == (start * 12) % 43200) {
+            answer++;
+        }
+
+        
+        for (int t = start; t < end; t++) {
+            int curT = t % 43200;
+            long s_start = (curT * 720) % 43200;
+            long m_start = (curT * 12) % 43200;
+            long h_start = (curT * 1) % 43200;
+
+            long s_end = s_start + 720;
+            long m_end = m_start + 12;
+            long h_end = h_start + 1;
+
+            boolean crossM = (s_start < m_start && s_end >= m_end);
+            boolean crossH = (s_start < h_start && s_end >= h_end);
+
+            if (crossM && crossH) {
+                
+                if ((m_start - s_start) * 719 == (h_start - s_start) * 708) {
+                    answer += 1;
+                } else {
+                    answer += 2;
+                }
+            } else if (crossM || crossH) {
+                answer += 1;
+            }
+        }
+
+        return answer;
+    }
+}

--- a/solve/hyunseung/programmers/[251035] 아날로그 시계2.java
+++ b/solve/hyunseung/programmers/[251035] 아날로그 시계2.java
@@ -1,0 +1,42 @@
+class Solution {
+    public int solution(int h1, int m1, int s1, int h2, int m2, int s2) {
+        int answer = 0;
+
+
+        int start = h1 * 3600 + m1 * 60 + s1;
+        int end = h2 * 3600 + m2 * 60 + s2;
+
+        
+        if (start % 43200 == 0 || (start * 720) % 43200 == (start * 12) % 43200) {
+            answer++;
+        }
+
+        
+        for (int t = start; t < end; t++) {
+            int curT = t % 43200;
+            long s_start = (curT * 720) % 43200;
+            long m_start = (curT * 12) % 43200;
+            long h_start = (curT * 1) % 43200;
+
+            long s_end = s_start + 720;
+            long m_end = m_start + 12;
+            long h_end = h_start + 1;
+
+            boolean crossM = (s_start < m_start && s_end >= m_end);
+            boolean crossH = (s_start < h_start && s_end >= h_end);
+
+            if (crossM && crossH) {
+                
+                if ((m_start - s_start) * 719 == (h_start - s_start) * 708) {
+                    answer += 1;
+                } else {
+                    answer += 2;
+                }
+            } else if (crossM || crossH) {
+                answer += 1;
+            }
+        }
+
+        return answer;
+    }
+}


### PR DESCRIPTION
## 문제
<!-- 문제 제목과 링크를 첨부해주세요. -->
- 문제: https://school.programmers.co.kr/learn/courses/30/lessons/250135
<br>

## 문제 요약
<!-- 문제에 대한 간단한 요약 설명을 작성해주세요. -->
- 시침, 분침, 초침이 있는 아날로그 시계에서 특정 시작 시간부터 종료 시간까지 초침이 시침 또는 분침과 겹치는 총 횟수를 구하는 문제입니다.
<br>

## 사용 알고리즘
<!-- 문제 풀이에 사용한 알고리즘 종류를 나열해주세요. (예: DFS, 문자열, 정렬 등) -->
- 수학 및 시뮬레이션 (정수 좌표계 변환)
<br>

## 풀이 해설
<!-- 문제 접근 방식, 시행착오, 코드에 대한 설명(알고리즘 적용 방식, 시간/공간복잡도 등)을 작성해주세요. -->
- 1초 단위 시뮬레이션: 전체 시간이 최대 86,400초로 매우 작으므로, 시작 초부터 종료 초까지 1초씩 진행하며 바늘의 위치를 추적합니다.
- 정수 연산 최적화: 소수점 오차를 방지하기 위해 시계 한 바퀴를 43,200 단위의 정수로 변환합니다.
- 교차(추월) 조건: 각 1초 구간 동안 초침이 시침/분침보다 뒤에 있다가 앞지르는 경우(시작위치 < target 이고 종료위치 >= target)를 찾아 카운트합니다.
- 동시 중첩 처리: 한 구간 내에서 시침과 분침을 모두 추월했을 때, 정확히 같은 정밀 시점에 만났는지 비례식으로 판별하여 중복 카운트를 방지합니다.
- 시간 복잡도: $O(N)$